### PR TITLE
add :iterable, :cursor annotations

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ where foo = :foo;
 import { Pool } from "pg";
 import { Query, UpdateQuery, QueryMany, MultiStatement } from "./module.sql";
 
-const pool = new Pool('...');
+const pool = new Pool("...");
 
 const { id } = await Query(pool, { id: 1 });
 
@@ -81,7 +81,7 @@ The only 4 sqlc annotations that are available are the following:
 
     ex.: `Query(c): Promise<number>`
 
-2 additional annotations not found in sqlc are available:
+4 additional annotations not found in sqlc are available:
 
 -   `:prepare` - prepares the statement by passing query's name to query config.
 
@@ -130,6 +130,20 @@ The only 4 sqlc annotations that are available are the following:
     ex. `:one`: `Query<R = [ ... ]>(c): Promise<R>`
 
     ex. `:many`: `Query<R = [ ... ]>(c): Promise<R[]>`
+
+-   `:iterable` - returns an `AsyncGenerator`. Once [Async Iterator Helpers](https://github.com/tc39/proposal-async-iterator-helpers)
+    are in the standard, you can use crazy piping like following:
+
+```js
+const result = await IterableQuery<{ ... }>(c, { foo: 'bar' })
+    .flatMap(superComplicatedCodeThatIsMoreUsefulToRunFromJS)
+    .filter(Boolean)
+    .toArray();
+```
+
+-   `:cursor` - returns an `Cursor`
+
+    ex.:
 
 ## Configuring
 

--- a/README.md
+++ b/README.md
@@ -127,12 +127,12 @@ The only 4 sqlc annotations that are available are the following:
 
     ex. `:execresult`: `Query<R extends any[] = [ ... ]>(c): Promise<QueryArrayResult<R>>`
 
-    ex. `:one`: `Query<R = [ ... ]>(c): Promise<R>`
+    ex. `:one`: `Query<R extends any[] = [ ... ]>(c): Promise<R>`
 
-    ex. `:many`: `Query<R = [ ... ]>(c): Promise<R[]>`
+    ex. `:many`: `Query<R extends any[] = [ ... ]>(c): Promise<R[]>`
 
 -   `:iterable` - returns an `AsyncGenerator`. Once [Async Iterator Helpers](https://github.com/tc39/proposal-async-iterator-helpers)
-    are in the standard, you can use crazy piping like following:
+    are in the standard, you can use crazy piping as following:
 
 ```js
 const result = await IterableQuery<{ ... }>(c, { foo: 'bar' })
@@ -141,9 +141,19 @@ const result = await IterableQuery<{ ... }>(c, { foo: 'bar' })
     .toArray();
 ```
 
+Well maybe that didn't look too crazy, but if some filtering forces your squeel to become convoluted, and you're fine with moving
+some of that computation to JS, you can finally do that! Or at least when that proposal is in the language, that is.
+
 -   `:cursor` - returns an `Cursor`
 
-    ex.:
+<<<<<<< HEAD
+ex.:
+=======
+ex.: `Query<R extends QueryResultRow = { ... }>(c): Promise<Cursor<R>>`
+
+    ex. `:array`: `Query<R extends any[] = [ ... ]>(c): Promise<Cursor<R>>`
+
+> > > > > > > 77a627d (update readme)
 
 ## Configuring
 

--- a/README.md
+++ b/README.md
@@ -146,14 +146,9 @@ some of that computation to JS, you can finally do that! Or at least when that p
 
 -   `:cursor` - returns an `Cursor`
 
-<<<<<<< HEAD
-ex.:
-=======
 ex.: `Query<R extends QueryResultRow = { ... }>(c): Promise<Cursor<R>>`
 
     ex. `:array`: `Query<R extends any[] = [ ... ]>(c): Promise<Cursor<R>>`
-
-> > > > > > > 77a627d (update readme)
 
 ## Configuring
 

--- a/package.json
+++ b/package.json
@@ -25,6 +25,11 @@
 		"pg-cursor": "*",
 		"pg": "*"
 	},
+	"peerDependenciesMeta": {
+		"pg-cursor": {
+			"optional": true
+		}
+	},
 	"engines": {
 		"node": ">=22.0.0"
 	}

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
 		"vite": "^6"
 	},
 	"peerDependencies": {
+		"pg-cursor": "*",
 		"pg": "*"
 	},
 	"engines": {

--- a/parse.js
+++ b/parse.js
@@ -92,7 +92,9 @@ export function codegen(
 ) {
 	let dts = [
 		// `declare module '${modulePrefix}${filename}.sql' {`
-		`import type { Pool, ClientBase, QueryResultRow, QueryResult, QueryArrayResult } from 'pg';\nimport Cursor from 'pg-cursor';`,
+		`import type { Pool, ClientBase, QueryResultRow, QueryResult, QueryArrayResult } from 'pg';${
+			module.mode ? `\nimport Cursor from 'pg-cursor'` : ""
+		};`,
 	];
 	let js = [`import { escapeLiteral } from 'pg';`];
 

--- a/parse.js
+++ b/parse.js
@@ -154,7 +154,7 @@ export function ${module.name}<${module.returnSymbols
 				? `Cursor<R1>`
 				: module.mode === ":iterable"
 				? `AsyncGenerator<R1, void, unknown>`
-				: ` Promise<${module.multiStatement && "["}${module.returnSymbols
+				: `Promise<${module.multiStatement && "["}${module.returnSymbols
 						.map((_, i) =>
 							module.execution[i] === ":execresult"
 								? `Query${module.rowArray ? "Array" : ""}Result<R${i + 1}>`

--- a/parse.js
+++ b/parse.js
@@ -92,9 +92,7 @@ export function codegen(
 ) {
 	let dts = [
 		// `declare module '${modulePrefix}${filename}.sql' {`
-		`import type { Pool, ClientBase, QueryResultRow, QueryResult, QueryArrayResult } from 'pg';${
-			module.mode ? `\nimport Cursor from 'pg-cursor'` : ""
-		};`,
+		`import type { Pool, ClientBase, QueryResultRow, QueryResult, QueryArrayResult } from 'pg';`,
 	];
 	let js = [`import { escapeLiteral } from 'pg';`];
 
@@ -120,6 +118,7 @@ export function codegen(
 		}
 
 		if (module.mode) {
+			dts[0] = dts[0] += `\nimport Cursor from 'pg-cursor';`;
 			js.push(`import Cursor from 'pg-cursor';`);
 		}
 

--- a/parse.js
+++ b/parse.js
@@ -92,7 +92,7 @@ export function codegen(
 ) {
 	let dts = [
 		// `declare module '${modulePrefix}${filename}.sql' {`
-		`import type { Pool, ClientBase, QueryResultRow, QueryResult, QueryArrayResult } from 'pg';`,
+		`import type { Pool, ClientBase, QueryResultRow, QueryResult, QueryArrayResult } from 'pg';\nimport Cursor from 'pg-cursor';`,
 	];
 	let js = [`import { escapeLiteral } from 'pg';`];
 
@@ -115,6 +115,10 @@ export function codegen(
 
 		if (!module.rowArray) {
 			module.returnSymbols = module.returnSymbols.map((rs) => [...new Set(rs)]);
+		}
+
+		if (module.mode) {
+			js.push(`import Cursor from 'pg-cursor';`);
 		}
 
 		const keys = module.params
@@ -141,20 +145,28 @@ export function ${module.name}<${module.returnSymbols
 					  }${r.length > 3 ? "\n" : " "}}`
 			)
 			.join(", ")}>(
-	tx: Pool | ClientBase | Promise<ClientBase>,${keys.length ? `\n\tparams: Record<${keys}, unknown>` : ``}
-): Promise<${module.multiStatement && "["}${module.returnSymbols
-			.map((_, i) =>
-				module.execution[i] === ":execresult"
-					? `Query${module.rowArray ? "Array" : ""}Result<R${i + 1}>`
-					: module.execution[i] === ":one"
-					? `R${i + 1}`
-					: module.execution[i] === ":many"
-					? `R${i + 1}[]`
-					: module.execution[i] === ":execrows"
-					? `number`
-					: "unknown"
-			)
-			.join(", ")}${module.multiStatement && "]"}>;`);
+	tx: Pool | ClientBase | Promise<ClientBase>,${keys && `\n\tparams: Record<${keys}, unknown>,`}${
+			module.mode === ":iterable" ? `\n\tread?: number,` : ""
+		}
+): ${
+			module.mode === ":cursor"
+				? `Cursor<R1>`
+				: module.mode === ":iterable"
+				? `AsyncGenerator<R1, void, unknown>`
+				: ` Promise<${module.multiStatement && "["}${module.returnSymbols
+						.map((_, i) =>
+							module.execution[i] === ":execresult"
+								? `Query${module.rowArray ? "Array" : ""}Result<R${i + 1}>`
+								: module.execution[i] === ":one"
+								? `R${i + 1}`
+								: module.execution[i] === ":many"
+								? `R${i + 1}[]`
+								: module.execution[i] === ":execrows"
+								? `number`
+								: "unknown"
+						)
+						.join(", ")}${module.multiStatement && "]"}>`
+		};`);
 
 		const paramsString = module.params
 			.values()
@@ -178,26 +190,47 @@ export function ${module.name}<${module.returnSymbols
 		}
 
 		js.push(
-			`export const ${module.name} = async (tx, { ${paramsString} } = {}) => (await tx).query({
+			module.mode === ":cursor"
+				? `export const ${module.name} = async (tx${
+						paramsString && `, { ${paramsString} } = {}`
+				  }) => (await tx).query(new Cursor(\`${module.query}\`${paramsString && `, [ ${paramsString} ]`}${
+						module.rowArray ? `, { rowMode: "array" }` : ""
+				  }));`
+				: module.mode === ":iterable"
+				? `export async function* ${module.name}(tx, ${paramsString && `{ ${paramsString} } = {}, `}read = 10) {
+	const cursor = (await tx).query(new Cursor(\`${module.query}\`${paramsString && `, [ ${paramsString} ]`}${
+						module.rowArray ? `, { rowMode: "array" }` : ""
+				  }));
+	try {
+		let _read;
+		do {
+			_read = await cursor.read(read);
+			yield* _read;
+		} while (_read.length === read);
+	} finally {
+		await cursor.close();
+	}
+}`
+				: `export const ${module.name} = async (tx, { ${paramsString} } = {}) => (await tx).query({
 	${module.prepared ? `name: "${module.name}",` : ""}
 	text: \`${module.multiStatement ? module.query : module.query}\`,
 	values: [ ${module.multiStatement || paramsString} ],
 	${module.rowArray ? `rowMode: "array",` : ""}
 }).then((${module.multiStatement && "["}${module.returnSymbols.map((_, i) => `r${i + 1}`).join()}${
-				module.multiStatement && "]"
-			}) => ${module.multiStatement && "["}${module.returnSymbols
-				.map(
-					(_, i) =>
-						`r${i + 1}` +
-						(module.execution[i] === ":one"
-							? `.rows[0]`
-							: module.execution[i] === ":many"
-							? `.rows`
-							: module.execution[i] === ":execrows"
-							? `.rowCount`
-							: "")
-				)
-				.join()}${module.multiStatement && "]"});`
+						module.multiStatement && "]"
+				  }) => ${module.multiStatement && "["}${module.returnSymbols
+						.map(
+							(_, i) =>
+								`r${i + 1}` +
+								(module.execution[i] === ":one"
+									? `.rows[0]`
+									: module.execution[i] === ":many"
+									? `.rows`
+									: module.execution[i] === ":execrows"
+									? `.rowCount`
+									: "")
+						)
+						.join()}${module.multiStatement && "]"});`
 		);
 	}
 

--- a/parse.js
+++ b/parse.js
@@ -118,7 +118,7 @@ export function codegen(
 		}
 
 		if (module.mode) {
-			dts[0] = dts[0] += `\nimport Cursor from 'pg-cursor';`;
+			dts[0] += `\nimport Cursor from 'pg-cursor';`;
 			js.push(`import Cursor from 'pg-cursor';`);
 		}
 

--- a/parse.test.js
+++ b/parse.test.js
@@ -147,6 +147,6 @@ from t;
 test("test cursor query", (t) => {
 	const { js, dts } = unit.codegen(unit.parseModule(cursorQuery), "test.sql", false, "");
 	// console.log("codegen js", js);
-	console.log("==========================");
+	// console.log("==========================");
 	console.log("codegen dts", dts);
 });

--- a/parse.test.js
+++ b/parse.test.js
@@ -148,5 +148,5 @@ test("test cursor query", (t) => {
 	const { js, dts } = unit.codegen(unit.parseModule(cursorQuery), "test.sql", false, "");
 	// console.log("codegen js", js);
 	// console.log("==========================");
-	console.log("codegen dts", dts);
+	// console.log("codegen dts", dts);
 });

--- a/parse.test.js
+++ b/parse.test.js
@@ -146,7 +146,7 @@ from t;
 
 test("test cursor query", (t) => {
 	const { js, dts } = unit.codegen(unit.parseModule(cursorQuery), "test.sql", false, "");
-	console.log("codegen js", js);
+	// console.log("codegen js", js);
 	console.log("==========================");
 	console.log("codegen dts", dts);
 });

--- a/parse.test.js
+++ b/parse.test.js
@@ -80,6 +80,52 @@ select num * random(),
 from updated;
 `;
 
+const nonParsableModule = `select 1;`;
+
+const iterableQuery = `
+-- name: AnotherDel :iterable
+select *
+from t
+where stuff = :stuff;
+`;
+
+const cursorQuery = `
+-- name: AnotherDel :cursor :array
+select *
+from t;
+`;
+
+test("test simple module", (t) => {
+	try {
+		const [parsed] = unit.parseModule(simpleModule).toArray();
+		// console.log("parsed simple module", parsed);
+		t.assert.strictEqual(parsed.name, "Simple");
+		t.assert.strictEqual(parsed.execution, ":one");
+		t.assert.strictEqual(parsed.prepared, true);
+		t.assert.strictEqual(parsed.query, "select 1");
+		// console.log("params", parsed.params, parsed.params.size, parsed.params.size === 0);
+		// console.log("selectFields", parsed.selectFields, parsed.selectFields.size);
+		// t.assert.strictEqual(parsed.params.size(), 0);
+		t.assert.strictEqual(parsed.selectFields.length, 1);
+		t.assert.strictEqual(parsed.returningClause, undefined);
+	} catch (err) {
+		console.error(err);
+		throw err;
+	}
+});
+
+test("test multi-statement module", (t) => {
+	const [module] = unit.parseModule(multiStatementModule).toArray();
+	// console.log("parsed multi statement module", module);
+	t.assert.strictEqual(module.length, 2);
+});
+
+test("test delete module", (t) => {
+	const [module] = unit.parseModule(deleteModule).toArray();
+	// console.log("parsed delete module", module);
+	t.assert.deepEqual(module.name, "Del");
+});
+
 test("test multi module", (t) => {
 	const modules = unit.parseModule(multiModule).toArray();
 	// console.log("parsed multi module", modules);
@@ -102,24 +148,23 @@ test("test non parsable module", (t) => {
 	t.assert.deepEqual(modules.length, 0);
 });
 
-const realUseCaseTest = `
--- name: InsertMessage :one
-insert into account.messages (to_user, from_user, listing_table, listing_id, content)
-select :to, :from, tableoid::regclass, :listingId, :content
-from account.listing
-where id = :listingId
-returning messages.id;
-
--- name: MarkRead :one
-update account.messages
-set read_at = current_timestamp
-where id = :id and read_at is not null and to_user = :to
-returning from_user as "from";
-`;
-
-test("test real use case", (t) => {
-	const { js, dts } = unit.codegen(unit.parseModule(realUseCaseTest), "test.sql", false, "");
+test("test codegen", (t) => {
+	const { js, dts } = unit.codegen(unit.parseModule(multiModule), "test.sql", false, "");
 	// console.log("codegen js", js);
 	// console.log("==========================");
 	// console.log("codegen dts", dts);
+});
+
+test("test iterable query", (t) => {
+	const { js, dts } = unit.codegen(unit.parseModule(iterableQuery), "test.sql", false, "");
+	// console.log("codegen js", js);
+	// console.log("==========================");
+	// console.log("codegen dts", dts);
+});
+
+test("test cursor query", (t) => {
+	const { js, dts } = unit.codegen(unit.parseModule(cursorQuery), "test.sql", false, "");
+	console.log("codegen js", js);
+	console.log("==========================");
+	console.log("codegen dts", dts);
 });

--- a/parse.test.js
+++ b/parse.test.js
@@ -27,25 +27,6 @@ test("test simple module", (t) => {
 	}
 });
 
-test("test simple module", (t) => {
-	try {
-		const [parsed] = unit.parseModule(simpleModule).toArray();
-		// console.log("parsed simple module", parsed);
-		t.assert.strictEqual(parsed.name, "Simple");
-		t.assert.strictEqual(parsed.execution, ":one");
-		t.assert.strictEqual(parsed.prepared, true);
-		t.assert.strictEqual(parsed.query, "select 1");
-		// console.log("params", parsed.params, parsed.params.size, parsed.params.size === 0);
-		// console.log("selectFields", parsed.selectFields, parsed.selectFields.size);
-		// t.assert.strictEqual(parsed.params.size(), 0);
-		t.assert.strictEqual(parsed.selectFields.length, 1);
-		t.assert.strictEqual(parsed.returningClause.length, 0);
-	} catch (err) {
-		console.error(err);
-		throw err;
-	}
-});
-
 const multiStatementModule = `
 -- name: Multi :one
 select 1;
@@ -61,24 +42,12 @@ test("test multi-statement module", (t) => {
 	t.assert.strictEqual(module.length, 2);
 });
 
-test("test multi-statement module", (t) => {
-	const [module] = unit.parseModule(multiStatementModule).toArray();
-	// console.log("parsed multi statement module", module);
-	t.assert.strictEqual(module.length, 2);
-});
-
 const deleteModule = `
 -- name: Del :one
 delete from table
 where name = :name
 returning name, timestamp;
 `;
-
-test("test delete module", (t) => {
-	const [module] = unit.parseModule(deleteModule).toArray();
-	// console.log("parsed delete module", module);
-	t.assert.deepEqual(module.name, "Del");
-});
 
 test("test delete module", (t) => {
 	const [module] = unit.parseModule(deleteModule).toArray();

--- a/parse.test.js
+++ b/parse.test.js
@@ -125,20 +125,6 @@ test("test codegen", (t) => {
 	// console.log("codegen dts", dts);
 });
 
-const iterableQuery = `
--- name: AnotherDel :iterable
-select *
-from t
-where stuff = :stuff;
-`;
-
-test("test iterable query", (t) => {
-	const { js, dts } = unit.codegen(unit.parseModule(iterableQuery), "test.sql", false, "");
-	// console.log("codegen js", js);
-	// console.log("==========================");
-	// console.log("codegen dts", dts);
-});
-
 const nonParsableModule = `select 1;`;
 
 test("test non parsable module", (t) => {
@@ -164,6 +150,20 @@ returning from_user as "from";
 
 test("test real use case", (t) => {
 	const { js, dts } = unit.codegen(unit.parseModule(realUseCaseTest), "test.sql", false, "");
+	// console.log("codegen js", js);
+	// console.log("==========================");
+	// console.log("codegen dts", dts);
+});
+
+const iterableQuery = `
+-- name: AnotherDel :iterable
+select *
+from t
+where stuff = :stuff;
+`;
+
+test("test iterable query", (t) => {
+	const { js, dts } = unit.codegen(unit.parseModule(iterableQuery), "test.sql", false, "");
 	// console.log("codegen js", js);
 	// console.log("==========================");
 	// console.log("codegen dts", dts);

--- a/parse.test.js
+++ b/parse.test.js
@@ -133,6 +133,33 @@ test("test non parsable module", (t) => {
 	t.assert.deepEqual(modules.length, 0);
 });
 
+const iterableQuery = `
+-- name: AnotherDel :iterable
+select *
+from t
+where stuff = :stuff;
+`;
+
+test("test iterable query", (t) => {
+	const { js, dts } = unit.codegen(unit.parseModule(iterableQuery), "test.sql", false, "");
+	// console.log("codegen js", js);
+	// console.log("==========================");
+	// console.log("codegen dts", dts);
+});
+
+const cursorQuery = `
+-- name: AnotherDel :cursor :array
+select *
+from t;
+`;
+
+test("test cursor query", (t) => {
+	const { js, dts } = unit.codegen(unit.parseModule(cursorQuery), "test.sql", false, "");
+	console.log("codegen js", js);
+	console.log("==========================");
+	console.log("codegen dts", dts);
+});
+
 const realUseCaseTest = `
 -- name: InsertMessage :one
 insert into account.messages (to_user, from_user, listing_table, listing_id, content)

--- a/parse.test.js
+++ b/parse.test.js
@@ -27,6 +27,25 @@ test("test simple module", (t) => {
 	}
 });
 
+test("test simple module", (t) => {
+	try {
+		const [parsed] = unit.parseModule(simpleModule).toArray();
+		// console.log("parsed simple module", parsed);
+		t.assert.strictEqual(parsed.name, "Simple");
+		t.assert.strictEqual(parsed.execution, ":one");
+		t.assert.strictEqual(parsed.prepared, true);
+		t.assert.strictEqual(parsed.query, "select 1");
+		// console.log("params", parsed.params, parsed.params.size, parsed.params.size === 0);
+		// console.log("selectFields", parsed.selectFields, parsed.selectFields.size);
+		// t.assert.strictEqual(parsed.params.size(), 0);
+		t.assert.strictEqual(parsed.selectFields.length, 1);
+		t.assert.strictEqual(parsed.returningClause.length, 0);
+	} catch (err) {
+		console.error(err);
+		throw err;
+	}
+});
+
 const multiStatementModule = `
 -- name: Multi :one
 select 1;
@@ -42,12 +61,24 @@ test("test multi-statement module", (t) => {
 	t.assert.strictEqual(module.length, 2);
 });
 
+test("test multi-statement module", (t) => {
+	const [module] = unit.parseModule(multiStatementModule).toArray();
+	// console.log("parsed multi statement module", module);
+	t.assert.strictEqual(module.length, 2);
+});
+
 const deleteModule = `
 -- name: Del :one
 delete from table
 where name = :name
 returning name, timestamp;
 `;
+
+test("test delete module", (t) => {
+	const [module] = unit.parseModule(deleteModule).toArray();
+	// console.log("parsed delete module", module);
+	t.assert.deepEqual(module.name, "Del");
+});
 
 test("test delete module", (t) => {
 	const [module] = unit.parseModule(deleteModule).toArray();
@@ -80,52 +111,6 @@ select num * random(),
 from updated;
 `;
 
-const nonParsableModule = `select 1;`;
-
-const iterableQuery = `
--- name: AnotherDel :iterable
-select *
-from t
-where stuff = :stuff;
-`;
-
-const cursorQuery = `
--- name: AnotherDel :cursor :array
-select *
-from t;
-`;
-
-test("test simple module", (t) => {
-	try {
-		const [parsed] = unit.parseModule(simpleModule).toArray();
-		// console.log("parsed simple module", parsed);
-		t.assert.strictEqual(parsed.name, "Simple");
-		t.assert.strictEqual(parsed.execution, ":one");
-		t.assert.strictEqual(parsed.prepared, true);
-		t.assert.strictEqual(parsed.query, "select 1");
-		// console.log("params", parsed.params, parsed.params.size, parsed.params.size === 0);
-		// console.log("selectFields", parsed.selectFields, parsed.selectFields.size);
-		// t.assert.strictEqual(parsed.params.size(), 0);
-		t.assert.strictEqual(parsed.selectFields.length, 1);
-		t.assert.strictEqual(parsed.returningClause, undefined);
-	} catch (err) {
-		console.error(err);
-		throw err;
-	}
-});
-
-test("test multi-statement module", (t) => {
-	const [module] = unit.parseModule(multiStatementModule).toArray();
-	// console.log("parsed multi statement module", module);
-	t.assert.strictEqual(module.length, 2);
-});
-
-test("test delete module", (t) => {
-	const [module] = unit.parseModule(deleteModule).toArray();
-	// console.log("parsed delete module", module);
-	t.assert.deepEqual(module.name, "Del");
-});
-
 test("test multi module", (t) => {
 	const modules = unit.parseModule(multiModule).toArray();
 	// console.log("parsed multi module", modules);
@@ -140,6 +125,20 @@ test("test codegen", (t) => {
 	// console.log("codegen dts", dts);
 });
 
+const iterableQuery = `
+-- name: AnotherDel :iterable
+select *
+from t
+where stuff = :stuff;
+`;
+
+test("test iterable query", (t) => {
+	const { js, dts } = unit.codegen(unit.parseModule(iterableQuery), "test.sql", false, "");
+	// console.log("codegen js", js);
+	// console.log("==========================");
+	// console.log("codegen dts", dts);
+});
+
 const nonParsableModule = `select 1;`;
 
 test("test non parsable module", (t) => {
@@ -148,19 +147,33 @@ test("test non parsable module", (t) => {
 	t.assert.deepEqual(modules.length, 0);
 });
 
-test("test codegen", (t) => {
-	const { js, dts } = unit.codegen(unit.parseModule(multiModule), "test.sql", false, "");
+const realUseCaseTest = `
+-- name: InsertMessage :one
+insert into account.messages (to_user, from_user, listing_table, listing_id, content)
+select :to, :from, tableoid::regclass, :listingId, :content
+from account.listing
+where id = :listingId
+returning messages.id;
+
+-- name: MarkRead :one
+update account.messages
+set read_at = current_timestamp
+where id = :id and read_at is not null and to_user = :to
+returning from_user as "from";
+`;
+
+test("test real use case", (t) => {
+	const { js, dts } = unit.codegen(unit.parseModule(realUseCaseTest), "test.sql", false, "");
 	// console.log("codegen js", js);
 	// console.log("==========================");
 	// console.log("codegen dts", dts);
 });
 
-test("test iterable query", (t) => {
-	const { js, dts } = unit.codegen(unit.parseModule(iterableQuery), "test.sql", false, "");
-	// console.log("codegen js", js);
-	// console.log("==========================");
-	// console.log("codegen dts", dts);
-});
+const cursorQuery = `
+-- name: AnotherDel :cursor :array
+select *
+from t;
+`;
 
 test("test cursor query", (t) => {
 	const { js, dts } = unit.codegen(unit.parseModule(cursorQuery), "test.sql", false, "");

--- a/parse.test.js
+++ b/parse.test.js
@@ -125,6 +125,7 @@ test("test codegen", (t) => {
 	// console.log("codegen dts", dts);
 });
 
+<<<<<<< HEAD
 const nonParsableModule = `select 1;`;
 
 test("test non parsable module", (t) => {
@@ -133,6 +134,8 @@ test("test non parsable module", (t) => {
 	t.assert.deepEqual(modules.length, 0);
 });
 
+=======
+>>>>>>> 68df3b2 (fixed a whole lotta bugs)
 const iterableQuery = `
 -- name: AnotherDel :iterable
 select *
@@ -147,6 +150,39 @@ test("test iterable query", (t) => {
 	// console.log("codegen dts", dts);
 });
 
+<<<<<<< HEAD
+=======
+const nonParsableModule = `select 1;`;
+
+test("test non parsable module", (t) => {
+	const modules = unit.parseModule(nonParsableModule).toArray();
+	// console.log("non parsable module", modules);
+	t.assert.deepEqual(modules.length, 0);
+});
+
+const realUseCaseTest = `
+-- name: InsertMessage :one
+insert into account.messages (to_user, from_user, listing_table, listing_id, content)
+select :to, :from, tableoid::regclass, :listingId, :content
+from account.listing
+where id = :listingId
+returning messages.id;
+
+-- name: MarkRead :one
+update account.messages
+set read_at = current_timestamp
+where id = :id and read_at is not null and to_user = :to
+returning from_user as "from";
+`;
+
+test("test real use case", (t) => {
+	const { js, dts } = unit.codegen(unit.parseModule(realUseCaseTest), "test.sql", false, "");
+	// console.log("codegen js", js);
+	// console.log("==========================");
+	// console.log("codegen dts", dts);
+});
+
+>>>>>>> 68df3b2 (fixed a whole lotta bugs)
 const cursorQuery = `
 -- name: AnotherDel :cursor :array
 select *

--- a/parse.test.js
+++ b/parse.test.js
@@ -125,75 +125,12 @@ test("test codegen", (t) => {
 	// console.log("codegen dts", dts);
 });
 
-<<<<<<< HEAD
 const nonParsableModule = `select 1;`;
 
 test("test non parsable module", (t) => {
 	const modules = unit.parseModule(nonParsableModule).toArray();
 	// console.log("non parsable module", modules);
 	t.assert.deepEqual(modules.length, 0);
-});
-
-=======
->>>>>>> 68df3b2 (fixed a whole lotta bugs)
-const iterableQuery = `
--- name: AnotherDel :iterable
-select *
-from t
-where stuff = :stuff;
-`;
-
-test("test iterable query", (t) => {
-	const { js, dts } = unit.codegen(unit.parseModule(iterableQuery), "test.sql", false, "");
-	// console.log("codegen js", js);
-	// console.log("==========================");
-	// console.log("codegen dts", dts);
-});
-
-<<<<<<< HEAD
-=======
-const nonParsableModule = `select 1;`;
-
-test("test non parsable module", (t) => {
-	const modules = unit.parseModule(nonParsableModule).toArray();
-	// console.log("non parsable module", modules);
-	t.assert.deepEqual(modules.length, 0);
-});
-
-const realUseCaseTest = `
--- name: InsertMessage :one
-insert into account.messages (to_user, from_user, listing_table, listing_id, content)
-select :to, :from, tableoid::regclass, :listingId, :content
-from account.listing
-where id = :listingId
-returning messages.id;
-
--- name: MarkRead :one
-update account.messages
-set read_at = current_timestamp
-where id = :id and read_at is not null and to_user = :to
-returning from_user as "from";
-`;
-
-test("test real use case", (t) => {
-	const { js, dts } = unit.codegen(unit.parseModule(realUseCaseTest), "test.sql", false, "");
-	// console.log("codegen js", js);
-	// console.log("==========================");
-	// console.log("codegen dts", dts);
-});
-
->>>>>>> 68df3b2 (fixed a whole lotta bugs)
-const cursorQuery = `
--- name: AnotherDel :cursor :array
-select *
-from t;
-`;
-
-test("test cursor query", (t) => {
-	const { js, dts } = unit.codegen(unit.parseModule(cursorQuery), "test.sql", false, "");
-	console.log("codegen js", js);
-	console.log("==========================");
-	console.log("codegen dts", dts);
 });
 
 const realUseCaseTest = `


### PR DESCRIPTION
Buggy due to https://github.com/brianc/node-postgres/issues/1860

adds stuff like the following:

```sql
-- name: Iterable :iterable
select * from t;
```

```js
import { Iterable } from './iterable.sql';

for await (const row of await Iterable(db)) {
  // stuff
}
```
